### PR TITLE
Allowed users to edit categories

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -11,6 +11,7 @@ import { CreatePosts } from "./posts/CreatePosts.js"
 import { MyPosts } from "./posts/MyPosts.js"
 import { PostsByUser } from "./posts/PostsByUser.js"
 import { SinglePost } from "./posts/SinglePost.js"
+import { NewCategoryForm } from "./categories/CreateCategoryForm.js"
 
 export const ApplicationViews = () => {
   return (
@@ -45,12 +46,11 @@ export const ApplicationViews = () => {
       <Route exact path="/posts/user/:userId(\d+)">
         <PostsByUser />
       </Route>
-      {/* 
-      <Route exact path="/posts/create">
-        <CreatePost />
-      </Route> */}
       <Route exact path="/categories">
         <AllCategories />
+      </Route>
+      <Route exact path="/editCategory/:categoryId(\d+)">
+        <NewCategoryForm editing={true} />
       </Route>
     </>
   )

--- a/src/components/categories/Categories.css
+++ b/src/components/categories/Categories.css
@@ -1,0 +1,7 @@
+.return-button {
+    margin-left: .5rem;
+}
+
+.category-input {
+    margin-left: .25rem;
+}

--- a/src/components/categories/CategoryManager.js
+++ b/src/components/categories/CategoryManager.js
@@ -6,8 +6,16 @@ export const getAllCategories = () => {
   return fetchIt(`${Settings.API}/categories`)
 }
 
+export const getSingleCategory = (categoryId) => {
+  return fetchIt(`${Settings.API}/categories/${categoryId}`)
+}
+
 export const createCategory = (newCategory) => {
   return fetchIt(`${Settings.API}/categories`, "POST", JSON.stringify(newCategory))
+}
+
+export const updateCategory = (newCategory) => {
+  return fetchIt(`${Settings.API}/categories/${newCategory.id}`, "PUT", JSON.stringify(newCategory))
 }
 
 export const deleteCategory = (categoryId) => {

--- a/src/components/categories/CreateCategoryForm.js
+++ b/src/components/categories/CreateCategoryForm.js
@@ -83,13 +83,21 @@ export const NewCategoryForm = ({ getCategories, editing }) => {
                         }
                     />
                     <div className="submitButtonCreateNewCategoryForm">
-
+                        {editing ?
+                        <button onClick={(e) => {
+                            submitNewCategory(e)
+                            updateForm({ label: "" })
+                        }} className="submit-button">
+                            Save
+                        </button>
+                        :
                         <button onClick={(e) => {
                             submitNewCategory(e)
                             updateForm({ label: "" })
                         }} className="submit-button">
                             Submit
                         </button>
+                        }
                         {editing ?
                             <button onClick={() => {
                                 history.push("/categories")

--- a/src/components/categories/CreateCategoryForm.js
+++ b/src/components/categories/CreateCategoryForm.js
@@ -1,110 +1,100 @@
 // imports
 import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import { useHistory } from "react-router-dom";
-import { fetchIt } from "../utils/Fetch"
-import { Settings } from "../utils/Settings"
-import { createCategory } from "./CategoryManager";
+import { createCategory, getSingleCategory, updateCategory } from "./CategoryManager";
 
 // def a function that will return a new category form
 
-export const NewCategoryForm = ({ getCategories }) => {
+export const NewCategoryForm = ({ getCategories, editing }) => {
 
-    const [form, updateForm] = useState({label: ""})
+    const [form, updateForm] = useState({ label: "" })
     const history = useHistory()
+    const { categoryId } = useParams()
 
-// const [form, updateForm] = useState()
+    useEffect(
+        () => {
+            if (editing) {
+                getSingleCategory(categoryId)
+                    .then(updateForm)
+            }
+        }, []
+    )
 
+    const submitNewCategory = (e) => {
+        e.preventDefault()
+        const newCategory = {
+            label: form.label,
+        }
+        if (editing) {
+            const updatedCategory = {
+                id: form.id,
+                label: form.label
+            }
+            updateCategory(updatedCategory)
+            .then(
+                () => {
+                    history.push("/categories")
+                })
+        }
+        else {
+        createCategory(newCategory)
+            .then(getCategories)
+        }
+    }
 
-// create a submitNewCategory button which will submit a new category to the server
-  // accepts one parameter, "e"
-    // e.preventDefault()
-        // defines a new  variable which will be an object for the new category, "newCategory"
-        // the object will have one key value pair:
-            // label: form.category
-                // define a new variable, fetchOption, method will be POST, headers will be "Content-Type": "application/json"
-                // convert what we're sending to the server into json body: JSON.stringify(newCategory)
-
-                const submitNewCategory = (e) => {
-                    e.preventDefault()
-                    const newCategory = {
-                        label: form.label,
-                    }
-                    createCategory(newCategory)
-                            .then(getCategories)
-                }
-
-        // post the newCategory to the Categories table in the db
-        // return fetch("http://localhost:8088/categories", fetchOption)
-
-        // example:
-
-        // const submitCategory = (e) => {
-        //     e.preventDefault()
-        //     const newCategory = {
-        //         label: form.label,
-        //     }
-        //     const fetchOption = {
-        //         method: "POST",
-        //         headers: {
-        //             "Content-Type": "application/json"
-        //         },
-        //         body: JSON.stringify(newCategory)
-        //     }
-
-        //     return fetch("http://localhost:8088/categories", fetchOption)
-        // }
-
-
-
-// return
+    // return
     // wrap in div className "form-group"
-        // <label htmlFor="category" "create a new category" as text for label
-        // input category
-            // required autoFocus
-            // type="text" id="category"
-            // className="form-control"
-            // placeholder="add text"
-                // add an onChange function to update what we will send to the server as the user types
-                    // accepts a parameter "e"
-                    //  => function body:
-                        // defines a new variable, copy, which is equal to { ...form}
-                        // set copy.label equal to e.target.value
-                        // change the value of form by using updateForm and passing in copy as an argument
+    // <label htmlFor="category" "create a new category" as text for label
+    // input category
+    // required autoFocus
+    // type="text" id="category"
+    // className="form-control"
+    // placeholder="add text"
+    // add an onChange function to update what we will send to the server as the user types
+    // accepts a parameter "e"
+    //  => function body:
+    // defines a new variable, copy, which is equal to { ...form}
+    // set copy.label equal to e.target.value
+    // change the value of form by using updateForm and passing in copy as an argument
 
-                        // example:
-                        return (
-                            <>
-                                <fieldset>
-                                    <div className="form-group">
-                                        <label htmlFor="category">Create a new category</label>
-                                        <input
-                                            required autoFocus
-                                            type="text" id="category"
-                                            className="form-control"
-                                            placeholder="add text"
-                                            value={form.label}
-                                            onChange={
-                                                (e) => {
-                                                    const copy = { ...form }
-                                                    copy.label = e.target.value
-                                                    updateForm(copy)
-                                                }
-                                            }
-                                        />
-                                        <div className="submitButtonCreateNewCategoryForm">
+    // example:
+    return (
+        <>
+            <fieldset>
+                <div className="form-group">
+                    {editing ?
+                        <label htmlFor="category">Update category</label>
+                        : <label htmlFor="category">Create a new category</label>
+                    }
+                    <input
+                        required autoFocus
+                        type="text" id="category"
+                        className="form-control"
+                        placeholder="add text"
+                        value={form.label}
+                        onChange={
+                            (e) => {
+                                const copy = { ...form }
+                                copy.label = e.target.value
+                                updateForm(copy)
+                            }
+                        }
+                    />
+                    <div className="submitButtonCreateNewCategoryForm">
 
-                                            <button onClick={(e) => {
-                                                submitNewCategory(e)
-                                                updateForm({label: ""})
-                                            }} className="submit-button">
-                                                Submit
-                                            </button>
-                                        </div>
-                                    </div>
-                                </fieldset>
-                            </>
-                        )
-                                        }
+                        <button onClick={(e) => {
+                            submitNewCategory(e)
+                            updateForm({ label: "" })
+                        }} className="submit-button">
+                            Submit
+                        </button>
+                    </div>
+                </div>
+            </fieldset>
+        </>
+    )
+}
 
 
 // add a button, which when clicked will invoke the submit new category function from the top of this module

--- a/src/components/categories/CreateCategoryForm.js
+++ b/src/components/categories/CreateCategoryForm.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useHistory } from "react-router-dom";
 import { createCategory, getSingleCategory, updateCategory } from "./CategoryManager";
+import "./Categories.css"
 
 // def a function that will return a new category form
 
@@ -32,14 +33,14 @@ export const NewCategoryForm = ({ getCategories, editing }) => {
                 label: form.label
             }
             updateCategory(updatedCategory)
-            .then(
-                () => {
-                    history.push("/categories")
-                })
+                .then(
+                    () => {
+                        history.push("/categories")
+                    })
         }
         else {
-        createCategory(newCategory)
-            .then(getCategories)
+            createCategory(newCategory)
+                .then(getCategories)
         }
     }
 
@@ -64,14 +65,14 @@ export const NewCategoryForm = ({ getCategories, editing }) => {
             <fieldset>
                 <div className="form-group">
                     {editing ?
-                        <label htmlFor="category">Update category</label>
-                        : <label htmlFor="category">Create a new category</label>
+                        <label htmlFor="category">Update category:</label>
+                        : <label htmlFor="category">Create a new category:</label>
                     }
                     <input
                         required autoFocus
                         type="text" id="category"
-                        className="form-control"
-                        placeholder="add text"
+                        className="category-input"
+                        placeholder="Add text..."
                         value={form.label}
                         onChange={
                             (e) => {
@@ -89,6 +90,14 @@ export const NewCategoryForm = ({ getCategories, editing }) => {
                         }} className="submit-button">
                             Submit
                         </button>
+                        {editing ?
+                            <button onClick={() => {
+                                history.push("/categories")
+                            }} className="return-button">
+                                Cancel
+                            </button>
+                            : ""
+                        }
                     </div>
                 </div>
             </fieldset>


### PR DESCRIPTION
# Description

Updated CategoryForm to allow for editing and updated application views to redirect to an edit form and back to categories list when the change has been submitted

Fixes #17 
## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Run python server
- [ ] npm start client
- [ ] Navigate to Category Manager tab in navbar
- [ ] Click the edit button on a category
- [ ] You should be redirected to an edit form and the input field should be filled with the category name you selected
- [ ] When you click submit you should be redirected back to the categories list and the name should reflect the changes
- [ ] When you click cancel you should be redirected back to the categories list page without changes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings