### PR TITLE
Kjc deactivate

### DIFF
--- a/src/components/buttonControls/ButtonControls.css
+++ b/src/components/buttonControls/ButtonControls.css
@@ -1,3 +1,17 @@
 .category_delete {
     margin-left: .5rem;
 }
+
+.reactivate {
+    width: 100%;
+    color: white;
+    background-color: red;
+    font-size: 18px;
+}
+
+.deactivate {
+    width: 100%;
+    color: white;
+    background-color: green;
+    font-size: 18px;
+}

--- a/src/components/buttonControls/ButtonControls.js
+++ b/src/components/buttonControls/ButtonControls.js
@@ -5,7 +5,7 @@ import { deleteCategory } from "../categories/CategoryManager"
 import { useHistory } from "react-router-dom"
 import "./ButtonControls.css"
 
-export const ButtonControls = ({ isPost, isCategory, isComment, isUser, postId, commentId, categoryId, user, getComments, getCategories, deactivate, reactivate }) => {
+export const ButtonControls = ({ isPost, isCategory, isComment, isUser, postId, commentId, categoryId, user, removeComment, getCategories, deactivate, reactivate }) => {
   const history = useHistory()
 
   return <div>
@@ -52,25 +52,20 @@ export const ButtonControls = ({ isPost, isCategory, isComment, isUser, postId, 
                   )
               }
               else if (isComment) {
-                deleteComment(commentId)
-                  .then(
-                    () => {
-                      getComments(postId)
-                    }
-                  )
-                  .then(
-                    () => {
+                removeComment(commentId)
                       const buttonTarget = document.querySelector(`#anything-${commentId}`)
                       buttonTarget.close()
-                    }
-                  )
               }
               else {
                 if (user.active) {
                   deactivate()
+                        const buttonTarget = document.querySelector(`#anything-${user.id}`)
+                        buttonTarget.close()
                 }
                 else {
                   reactivate()
+                        const buttonTarget = document.querySelector(`#anything-${user.id}`)
+                        buttonTarget.close()
                 }
               }
             }
@@ -112,11 +107,12 @@ export const ButtonControls = ({ isPost, isCategory, isComment, isUser, postId, 
             history.push(`/editComment/${commentId}`)
           }
         }}>
-        {isCategory ?
-          <div>Edit</div>
-          :
-          <img className="editIcon" src={`${Settings.EditIcon}`} width="25px" height="25px" />
-        }
+        {!isUser ?
+          isCategory ?
+            <div>Edit</div>
+            :
+            <img className="editIcon" src={`${Settings.EditIcon}`} width="25px" height="25px" />
+          : ""}
       </button>
       : ""
     }
@@ -136,11 +132,12 @@ export const ButtonControls = ({ isPost, isCategory, isComment, isUser, postId, 
             buttonTarget.showModal()
           }
         }}>
-        {isCategory ?
-          <div>Delete</div>
-          :
-          <img className="deleteIcon" src={`${Settings.DeleteIcon}`} width="25px" height="25px" />
-        }
+        {!isUser ?
+          isCategory ?
+            <div>Delete</div>
+            :
+            <img className="deleteIcon" src={`${Settings.DeleteIcon}`} width="25px" height="25px" />
+          : ""}
       </button>
       : ""
     }

--- a/src/components/buttonControls/ButtonControls.js
+++ b/src/components/buttonControls/ButtonControls.js
@@ -5,18 +5,23 @@ import { deleteCategory } from "../categories/CategoryManager"
 import { useHistory } from "react-router-dom"
 import "./ButtonControls.css"
 
-export const ButtonControls = ({ isPost, isCategory, postId, commentId, categoryId, getComments, getCategories }) => {
+export const ButtonControls = ({ isPost, isCategory, isComment, isUser, postId, commentId, categoryId, user, getComments, getCategories, deactivate, reactivate }) => {
   const history = useHistory()
 
   return <div>
-    <dialog id={isPost ? `anything-${postId}` : isCategory ? `anything-${categoryId}` : `anything-${commentId}`}>
+    <dialog id={isPost ? `anything-${postId}` : isCategory ? `anything-${categoryId}` : isComment ? `anything-${commentId}` : `anything-${user.id}`}>
       {
         isPost
           ? <div>Are you sure you want to delete this post?</div>
           :
           isCategory
             ? <div>Are you sure you want to delete this category?</div>
-            : <div>Are you sure you want to delete this comment?</div>
+            :
+            isComment
+              ? <div>Are you sure you want to delete this comment?</div>
+              : user.active
+                ? <div>Are you sure you want to deactivate this user?</div>
+                : <div>Are you sure you want to reactivate this user?</div>
       }
 
       <div>
@@ -46,7 +51,7 @@ export const ButtonControls = ({ isPost, isCategory, postId, commentId, category
                     }
                   )
               }
-              else {
+              else if (isComment) {
                 deleteComment(commentId)
                   .then(
                     () => {
@@ -60,6 +65,14 @@ export const ButtonControls = ({ isPost, isCategory, postId, commentId, category
                     }
                   )
               }
+              else {
+                if (user.active) {
+                  deactivate()
+                }
+                else {
+                  reactivate()
+                }
+              }
             }
           }
         >Okay</button>
@@ -70,13 +83,16 @@ export const ButtonControls = ({ isPost, isCategory, postId, commentId, category
               if (isPost) {
                 const buttonTarget = document.querySelector(`#anything-${postId}`)
                 buttonTarget.close()
-                } else if (isCategory) {
+              } else if (isCategory) {
                 const buttonTarget = document.querySelector(`#anything-${categoryId}`)
                 buttonTarget.close()
-                } else {
-                 const buttonTarget = document.querySelector(`#anything-${commentId}`)
-                 buttonTarget.close()
-                }
+              } else if (isComment) {
+                const buttonTarget = document.querySelector(`#anything-${commentId}`)
+                buttonTarget.close()
+              } else {
+                const buttonTarget = document.querySelector(`#anything-${user.id}`)
+                buttonTarget.close()
+              }
             }
           }
         >Cancel
@@ -84,44 +100,71 @@ export const ButtonControls = ({ isPost, isCategory, postId, commentId, category
       </div>
 
     </dialog>
-    <button
-    className="category_edit"
-    onClick={() => {
-      if (isPost) {
-        history.push(`/editPost/${postId}`)
-      } else if (isCategory) {
-        history.push(`/editCategory/${categoryId}`)
-      } else {
-        history.push(`/editComment/${commentId}`)
-      }
-    }}>
-      {isCategory ?
-        <div>Edit</div>
+    {!isUser ?
+      <button
+        className="category_edit"
+        onClick={() => {
+          if (isPost) {
+            history.push(`/editPost/${postId}`)
+          } else if (isCategory) {
+            history.push(`/editCategory/${categoryId}`)
+          } else if (isComment) {
+            history.push(`/editComment/${commentId}`)
+          }
+        }}>
+        {isCategory ?
+          <div>Edit</div>
+          :
+          <img className="editIcon" src={`${Settings.EditIcon}`} width="25px" height="25px" />
+        }
+      </button>
+      : ""
+    }
+    {!isUser ?
+      <button
+        className="category_delete"
+        onClick={() => {
+          console.log(categoryId)
+          if (isPost) {
+            const buttonTarget = document.querySelector(`#anything-${postId}`)
+            buttonTarget.showModal()
+          } else if (isCategory) {
+            const buttonTarget = document.querySelector(`#anything-${categoryId}`)
+            buttonTarget.showModal()
+          } else if (isComment) {
+            const buttonTarget = document.querySelector(`#anything-${commentId}`)
+            buttonTarget.showModal()
+          }
+        }}>
+        {isCategory ?
+          <div>Delete</div>
+          :
+          <img className="deleteIcon" src={`${Settings.DeleteIcon}`} width="25px" height="25px" />
+        }
+      </button>
+      : ""
+    }
+    {isUser ?
+      user.active ?
+        <button
+          className="deactivate"
+          onClick={() => {
+            const buttonTarget = document.querySelector(`#anything-${user.id}`)
+            buttonTarget.showModal()
+          }}>
+          Deactivate
+        </button>
         :
-        <img className="editIcon" src={`${Settings.EditIcon}`} width="25px" height="25px" />
-      }
-    </button>
-    <button
-    className="category_delete"
-    onClick={() => {
-      console.log(categoryId)
-      if (isPost) {
-      const buttonTarget = document.querySelector(`#anything-${postId}`)
-      buttonTarget.showModal()
-      } else if (isCategory) {
-      const buttonTarget = document.querySelector(`#anything-${categoryId}`)
-      buttonTarget.showModal()
-      } else {
-       const buttonTarget = document.querySelector(`#anything-${commentId}`)
-       buttonTarget.showModal()
-      }
-    }}>
-      {isCategory ?
-        <div>Delete</div>
-        :
-        <img className="deleteIcon" src={`${Settings.DeleteIcon}`} width="25px" height="25px" />
-      }
-    </button>
+        <button
+          className="reactivate"
+          onClick={() => {
+            const buttonTarget = document.querySelector(`#anything-${user.id}`)
+            buttonTarget.showModal()
+          }}>
+          Reactivate
+        </button>
+      : ""
+    }
   </div >
 }
 

--- a/src/components/comments/Comment.js
+++ b/src/components/comments/Comment.js
@@ -20,6 +20,7 @@ export const Comment = ({ postId, commentObject, currentAuthor, getComments, las
         deleteComment(commentId)
             .then(() => getComments(postId))
     }
+
     const dateFormat = (obj) => {
         const copy = {...obj }
         const dateArray = copy.created_on.split('-')
@@ -27,6 +28,7 @@ export const Comment = ({ postId, commentObject, currentAuthor, getComments, las
         const newDate = `${dateArray[1]}-${dayArray[0]}-${dateArray[0]}`
         return newDate
     }
+
     return <div className="comment" >
         {/*
                 JSX for comment
@@ -44,9 +46,10 @@ export const Comment = ({ postId, commentObject, currentAuthor, getComments, las
                     <ButtonControls
                         isPost={false}
                         isComment={true}
+                        isUser={false}
                         postId={postId}
                         commentId={commentObject.id}
-                        getComments={getComments} />
+                        removeComment={removeComment} />
                 </div>
                 : null
         }

--- a/src/components/comments/Comment.js
+++ b/src/components/comments/Comment.js
@@ -43,6 +43,7 @@ export const Comment = ({ postId, commentObject, currentAuthor, getComments, las
                 ? <div>
                     <ButtonControls
                         isPost={false}
+                        isComment={true}
                         postId={postId}
                         commentId={commentObject.id}
                         getComments={getComments} />

--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -3,6 +3,7 @@ import { useHistory } from "react-router-dom"
 import { Link } from "react-router-dom"
 import { ButtonControls } from "../buttonControls/ButtonControls"
 import { CommentList } from "../comments/CommentsList"
+
 import "./Post.css"
 // function that renders a single post
 export const Post = ({ listView, cardView, post }) => {
@@ -11,6 +12,13 @@ export const Post = ({ listView, cardView, post }) => {
     const history = useHistory()
     // const currentUser = parseInt(localStorage.getItem("token"))
 
+    const dateFormat = (obj) => {
+        const copy = {...obj }
+        const dateArray = copy.publication_date.split('-')
+        const dayArray = dateArray[2].split('T')
+        const newDate = `${dateArray[1]}-${dayArray[0]}-${dateArray[0]}`
+        return newDate
+    }
 
     return <>
         {/* Content needed in all posts list */}
@@ -24,7 +32,7 @@ export const Post = ({ listView, cardView, post }) => {
                                 {post.title}
                             </Link>
                         </div>
-                        <div>{post.publication_date}</div>
+                        <div>{dateFormat(post)}</div>
                     </div>
                     <div className="cardImage">
                         <img src={`${post.imageURL || "https://picsum.photos/300/100"}`} />
@@ -56,7 +64,7 @@ export const Post = ({ listView, cardView, post }) => {
                             }
                         </div>
                         <div>{post.user.user.first_name} {post.user.user.last_name}</div>
-                        <div>{post.publication_date}</div>
+                        <div>{dateFormat(post)}</div>
                         <div>{post.category.label}</div>
                         <div>{post.tags?.map(tag => <div key={`posttag${post.id}${tag.id}`}>{tag.label}</div>)}</div>
                     </div>

--- a/src/components/users/User.css
+++ b/src/components/users/User.css
@@ -4,7 +4,7 @@
 }
 
 .singleUser > div {
-    width: 10rem;
+    width: 12rem;
     padding: 1rem;
     border: 1px black dashed;
 }

--- a/src/components/users/User.js
+++ b/src/components/users/User.js
@@ -10,6 +10,7 @@ import "./User.css"
 import { getSingleUser, reactivateUser, deactivateUser } from "./UserManager"
 import { Link } from "react-router-dom"
 import { SubForm } from "./SubForm"
+import { ButtonControls } from "../buttonControls/ButtonControls"
 
 // function that generates JSX for individual user element
 export const User = ({ listView, user }) => {
@@ -18,6 +19,7 @@ export const User = ({ listView, user }) => {
     const [viewUser, setViewUser] = useState(user)
     const [postCount, setPostCount] = useState(0)
     const [is_active, setActive] = useState(false)
+    const [is_admin, setAdmin] = useState(false)
     const { userId } = useParams()
 
     const activeSwitch = () => {
@@ -27,24 +29,24 @@ export const User = ({ listView, user }) => {
     }
 
     const deactivate = () => {
-        let copy = {...user}
+        let copy = { ...user }
         copy.active = false
         setViewUser(copy)
         deactivateUser(copy)
-        .then(activeSwitch)
+            .then(activeSwitch)
     }
 
     const reactivate = () => {
-        let copy = {...user}
+        let copy = { ...user }
         copy.active = true
         setViewUser(copy)
         reactivateUser(copy)
-        .then(activeSwitch)
+            .then(activeSwitch)
     }
 
     useEffect(
         () => {
-            if(!listView) {
+            if (!listView) {
                 getSingleUser(userId)
                     .then(userData => setViewUser(userData))
             }
@@ -53,16 +55,24 @@ export const User = ({ listView, user }) => {
 
     useEffect(
         () => {
-            if(viewUser) {
+            if (viewUser) {
                 let count = viewUser.posts?.length
                 setPostCount(count)
             }
         }, [viewUser]
     )
-        // define state variables
-        // maybe get user's articles for the clickable article count?
-        // articles, setArticles = useState()
-        // subscribed, setSubscribed = useState(false) // default could be false
+
+    useEffect(
+        () => {
+            if (user.user.is_staff === true) {
+                setAdmin(true)
+            }
+        }, []
+    )
+    // define state variables
+    // maybe get user's articles for the clickable article count?
+    // articles, setArticles = useState()
+    // subscribed, setSubscribed = useState(false) // default could be false
 
     // define useEffects
     // only needed for list view
@@ -79,42 +89,37 @@ export const User = ({ listView, user }) => {
             if viewer is subbed to viewed setSubscribed state to true
     */
     // does subscribe button need an onclick?
-        // yes
-        // if subbed - onclick calls delete sub function
-        // if not subbed - onclick calls add sub function
+    // yes
+    // if subbed - onclick calls delete sub function
+    // if not subbed - onclick calls add sub function
 
     return <>
         {listView
-            ? <div className="singleUser">
-                {
-                            viewUser.active ?
-                                // TODO: create the Leave button
-                                <button className="leave_button"
-                                    onClick={() => {
-                                        deactivate()
-                                    }}
-                                >
-                                    Deactivate
-                                </button>
-                                :
-                            // TODO: create the Join button
-                                <button className="join_button"
-                                    onClick={() => {
-                                        reactivate()
-                                    }}
-                                >
-                                    Reactivate
-                                </button>
-                        }
+            ?
+            <div className="singleUser">
+                {is_admin ?
+                    <div>
+                        <ButtonControls
+                            isPost={false}
+                            isComment={false}
+                            isUser={true}
+                            user={user}
+                            deactivate={deactivate}
+                            reactivate={reactivate}
+                        />
+                    </div>
+                    : ""
+                }
                 <div>
                     <Link to={`/users/${user.id}`}>
-                    {user.user.username}
+                        {user.user.username}
                     </Link>
                 </div>
                 <div>{user.user.first_name}</div>
                 <div>{user.user.last_name}</div>
                 <div>{user.user.email}</div>
             </div>
+
             : viewUser
                 ? <div>
                     <div>Picture: <img src={`${viewUser.user?.profileImageUrl || "https://m.media-amazon.com/images/I/91xDQaUMubS._AC_SL1500_.jpg"}`} width={300} height={300} /></div>
@@ -125,7 +130,7 @@ export const User = ({ listView, user }) => {
                     <div>Profile Type: Author</div>
                     <div>
                         <Link to={`/posts/user/${viewUser.id}`}>
-                        See Articles - Count: {postCount}
+                            See Articles - Count: {postCount}
                         </Link>
                     </div>
                     <div>
@@ -134,7 +139,7 @@ export const User = ({ listView, user }) => {
                 </div>
                 : null
         }
-    {/*
+        {/*
         JSX for the individual user
             in list form - just need name and link to individual page
 

--- a/src/components/users/User.js
+++ b/src/components/users/User.js
@@ -7,17 +7,40 @@
 import { useParams } from "react-router-dom"
 import { useEffect, useState } from "react"
 import "./User.css"
-import { getSingleUser } from "./UserManager"
+import { getSingleUser, reactivateUser, deactivateUser } from "./UserManager"
 import { Link } from "react-router-dom"
 import { SubForm } from "./SubForm"
 
 // function that generates JSX for individual user element
 export const User = ({ listView, user }) => {
-    // probably want a prop that indicates whether 
+    // probably want a prop that indicates whether
     // content is being generated in a list vs individual page
     const [viewUser, setViewUser] = useState(user)
     const [postCount, setPostCount] = useState(0)
+    const [is_active, setActive] = useState(false)
     const { userId } = useParams()
+
+    const activeSwitch = () => {
+        let currentValue = is_active
+        currentValue = !currentValue
+        setActive(currentValue)
+    }
+
+    const deactivate = () => {
+        let copy = {...user}
+        copy.active = false
+        setViewUser(copy)
+        deactivateUser(copy)
+        .then(activeSwitch)
+    }
+
+    const reactivate = () => {
+        let copy = {...user}
+        copy.active = true
+        setViewUser(copy)
+        reactivateUser(copy)
+        .then(activeSwitch)
+    }
 
     useEffect(
         () => {
@@ -46,12 +69,12 @@ export const User = ({ listView, user }) => {
     // useEffect(() => getArticlesForUser function then setArticles, [])
 
     /* useEffect(() => getSubscribedStatus)
-        this useEffect can run on page load 
+        this useEffect can run on page load
         needs to check if the viewing user is subscribed to the viewed user
         get subscribed list from database
             the database function should probably take id as param
             only returns subbed relationships of the viewing user
-        iterate over the sub list 
+        iterate over the sub list
             to check if viewed user is in the list
             if viewer is subbed to viewed setSubscribed state to true
     */
@@ -61,8 +84,28 @@ export const User = ({ listView, user }) => {
         // if not subbed - onclick calls add sub function
 
     return <>
-        {listView 
+        {listView
             ? <div className="singleUser">
+                {
+                            viewUser.active ?
+                                // TODO: create the Leave button
+                                <button className="leave_button"
+                                    onClick={() => {
+                                        deactivate()
+                                    }}
+                                >
+                                    Deactivate
+                                </button>
+                                :
+                            // TODO: create the Join button
+                                <button className="join_button"
+                                    onClick={() => {
+                                        reactivate()
+                                    }}
+                                >
+                                    Reactivate
+                                </button>
+                        }
                 <div>
                     <Link to={`/users/${user.id}`}>
                     {user.user.username}
@@ -71,7 +114,7 @@ export const User = ({ listView, user }) => {
                 <div>{user.user.first_name}</div>
                 <div>{user.user.last_name}</div>
                 <div>{user.user.email}</div>
-            </div> 
+            </div>
             : viewUser
                 ? <div>
                     <div>Picture: <img src={`${viewUser.user?.profileImageUrl || "https://m.media-amazon.com/images/I/91xDQaUMubS._AC_SL1500_.jpg"}`} width={300} height={300} /></div>
@@ -91,7 +134,7 @@ export const User = ({ listView, user }) => {
                 </div>
                 : null
         }
-    {/* 
+    {/*
         JSX for the individual user
             in list form - just need name and link to individual page
 
@@ -105,6 +148,6 @@ export const User = ({ listView, user }) => {
                 - clickable article count
                 - subscribe button - displays as either subscribe or unsubscribe
     */}
-    
+
     </>
 }

--- a/src/components/users/User.js
+++ b/src/components/users/User.js
@@ -13,27 +13,20 @@ import { SubForm } from "./SubForm"
 import { ButtonControls } from "../buttonControls/ButtonControls"
 
 // function that generates JSX for individual user element
-export const User = ({ listView, user }) => {
+export const User = ({ listView, user, currentUser, getUsers }) => {
     // probably want a prop that indicates whether
     // content is being generated in a list vs individual page
     const [viewUser, setViewUser] = useState(user)
     const [postCount, setPostCount] = useState(0)
-    const [is_active, setActive] = useState(false)
     const [is_admin, setAdmin] = useState(false)
     const { userId } = useParams()
-
-    const activeSwitch = () => {
-        let currentValue = is_active
-        currentValue = !currentValue
-        setActive(currentValue)
-    }
 
     const deactivate = () => {
         let copy = { ...user }
         copy.active = false
         setViewUser(copy)
         deactivateUser(copy)
-            .then(activeSwitch)
+            .then(() => getUsers())
     }
 
     const reactivate = () => {
@@ -41,7 +34,7 @@ export const User = ({ listView, user }) => {
         copy.active = true
         setViewUser(copy)
         reactivateUser(copy)
-            .then(activeSwitch)
+            .then(() => getUsers())
     }
 
     useEffect(
@@ -64,10 +57,12 @@ export const User = ({ listView, user }) => {
 
     useEffect(
         () => {
-            if (user.user.is_staff === true) {
-                setAdmin(true)
+            if (listView) {
+                if (currentUser?.user.is_staff === true) {
+                    setAdmin(true)
+                }
             }
-        }, []
+        }, [listView, currentUser]
     )
     // define state variables
     // maybe get user's articles for the clickable article count?

--- a/src/components/users/UserList.js
+++ b/src/components/users/UserList.js
@@ -3,7 +3,7 @@
 // get all users fetch
 import { useEffect, useState } from "react"
 import { User } from "./User"
-import { getAllUsers } from "./UserManager"
+import { getAllUsers, getCurrentUser } from "./UserManager"
 
 // function that generates list of users
 // invokes User function from User.js for each user
@@ -11,14 +11,23 @@ export const UserList = () => {
     // define needed state variables
     // users, setUsers = useState()
     const [users, setUsers] = useState([])
+    const [currentUser, setCurrentUser] = useState()
+
+    const getUsers = () => {
+        getAllUsers()
+            .then(setUsers)
+    }
 
     // define needed useEffects
     // useEffect(() => getUsers function and set as users state variable, [])
     useEffect(() => {
-        getAllUsers()
-            .then(userData => {
-                setUsers(userData)
-            })
+        getUsers()
+    }, [])
+
+    useEffect(
+        () => {
+        getCurrentUser()
+        .then(setCurrentUser)
     }, [])
     // define needed functions
     // will the users have any buttons?
@@ -36,7 +45,7 @@ export const UserList = () => {
     {
         users?.map(user => {
             return <div key={`user-${user.id}`}>
-                <User user={user} listView={true} />
+                <User user={user} listView={true} currentUser={currentUser} getUsers={getUsers} />
             </div>
         })
     }

--- a/src/components/users/UserList.js
+++ b/src/components/users/UserList.js
@@ -40,7 +40,7 @@ export const UserList = () => {
             </div>
         })
     }
-    {/* 
+    {/*
         map over users and invoke <User /> component for each
         add any other jsx tags as needed for styling
     */}

--- a/src/components/users/UserManager.js
+++ b/src/components/users/UserManager.js
@@ -19,6 +19,10 @@ export const getSingleUser = (id) => {
     return fetchIt(`${Settings.API}/users/${id}`)
 }
 
+export const getCurrentUser = () => {
+    return fetchIt(`${Settings.API}/users/0`)
+}
+
 export const deactivateUser = (user) => {
     return fetchIt(`${Settings.API}/users/${user.id}/deactivate`, "PUT", JSON.stringify(user))
 }

--- a/src/components/users/UserManager.js
+++ b/src/components/users/UserManager.js
@@ -18,3 +18,11 @@ export const getAllUsers = () => {
 export const getSingleUser = (id) => {
     return fetchIt(`${Settings.API}/users/${id}`)
 }
+
+export const deactivateUser = (user) => {
+    return fetchIt(`${Settings.API}/users/${user.id}/deactivate`, "PUT", JSON.stringify(user))
+}
+
+export const reactivateUser = (user) => {
+    return fetchIt(`${Settings.API}/users/${user.id}/reactivate`, "PUT", JSON.stringify(user))
+}


### PR DESCRIPTION
# Description

Updated ButtonsControls component to allow for use for an admin to deactivate and reactivate user accounts.

Fixes #28 
Fixes #29

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Run python server
- [ ] npm start client
- [ ] loaddata users after creating another user in your fixtures with is_staff = true
- [ ] Log in as your new "admin"
- [ ] Navigates to users in the navbar
- [ ] There should be buttons next to the users names that let you deactivate/reactivate user accounts
- [ ] Deactivate an user then log out
- [ ] Try logging as that user, and it should now act as if that user doesn't exist
- [ ] Log back is as the admin and reactivate that user then log back out
- [ ] Try logging in as the newly reactivated user to make sure it works
- [ ] While logged in a normal user navigate to the users in navbar to ensure the buttons aren't visible unless you're an admin 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings