### PR TITLE
Two admins 

### DIFF
--- a/src/components/buttonControls/ButtonControls.js
+++ b/src/components/buttonControls/ButtonControls.js
@@ -5,7 +5,7 @@ import { deleteCategory } from "../categories/CategoryManager"
 import { useHistory } from "react-router-dom"
 import "./ButtonControls.css"
 
-export const ButtonControls = ({ isPost, isCategory, isComment, isUser, adminEdit, postId, commentId, categoryId, user, removeComment, getCategories, deactivate, reactivate, removeAdmin, addAdmin }) => {
+export const ButtonControls = ({ isPost, isCategory, isComment, isUser, adminEdit, postId, commentId, categoryId, user, removeComment, getCategories, deactivate, reactivate, removeAdmin, addAdmin, currentUser }) => {
   const history = useHistory()
 
   return <div>
@@ -67,13 +67,13 @@ export const ButtonControls = ({ isPost, isCategory, isComment, isUser, adminEdi
               }
               else if (adminEdit) {
                 if (user.is_admin) {
-                  if (user.admin_count > 1) {
+                  if (user.admin_approval === currentUser.id) {
+                    alert("You've already approved this demotion, another admin must be the other approval.")
+                  }
+                  else {
                     removeAdmin()
                     const buttonTarget = document.querySelector(`#anything-${user.user.username}`)
                     buttonTarget.close()
-                  }
-                  else {
-                    alert("You must pass admin privileges to another user before removing the last admin")
                   }
                 }
                 else {
@@ -84,9 +84,14 @@ export const ButtonControls = ({ isPost, isCategory, isComment, isUser, adminEdi
               }
               else if (isUser && !adminEdit) {
                 if (user.active) {
-                  deactivate()
-                  const buttonTarget = document.querySelector(`#anything-${user.id}`)
-                  buttonTarget.close()
+                  if (user.admin_approval === currentUser.id) {
+                    alert("You've already approved this deactivation, another admin must be the other approval.")
+                  }
+                  else {
+                    deactivate()
+                    const buttonTarget = document.querySelector(`#anything-${user.id}`)
+                    buttonTarget.close()
+                  }
                 }
                 else {
                   reactivate()
@@ -182,7 +187,7 @@ export const ButtonControls = ({ isPost, isCategory, isComment, isUser, adminEdi
               }}>
               Demote
             </button>
-            <h2>Admins approved: {user.admin_approval}</h2>
+            <h2>Admins approved: {user.admin_approval == 0 ? "0" : "1"}</h2>
           </div>
           :
           <button
@@ -204,7 +209,7 @@ export const ButtonControls = ({ isPost, isCategory, isComment, isUser, adminEdi
               }}>
               Deactivate
             </button>
-            <h2>Admins approved: {user.admin_approval}</h2>
+            <h2>Admins approved: {user.admin_approval == 0 ? "0" : "1"}</h2>
           </div>
           :
           <button

--- a/src/components/buttonControls/ButtonControls.js
+++ b/src/components/buttonControls/ButtonControls.js
@@ -173,14 +173,17 @@ export const ButtonControls = ({ isPost, isCategory, isComment, isUser, adminEdi
     {isUser ?
       adminEdit ?
         user.is_admin ?
-          <button
-            className="demote"
-            onClick={() => {
-              const buttonTarget = document.querySelector(`#anything-${user.user.username}`)
-              buttonTarget.showModal()
-            }}>
-            Demote
-          </button>
+          <div>
+            <button
+              className="demote"
+              onClick={() => {
+                const buttonTarget = document.querySelector(`#anything-${user.user.username}`)
+                buttonTarget.showModal()
+              }}>
+              Demote
+            </button>
+            <h2>Admins approved: {user.admin_approval}</h2>
+          </div>
           :
           <button
             className="promote"
@@ -192,14 +195,17 @@ export const ButtonControls = ({ isPost, isCategory, isComment, isUser, adminEdi
           </button>
         :
         user.active ?
-          <button
-            className="deactivate"
-            onClick={() => {
-              const buttonTarget = document.querySelector(`#anything-${user.id}`)
-              buttonTarget.showModal()
-            }}>
-            Deactivate
-          </button>
+          <div>
+            <button
+              className="deactivate"
+              onClick={() => {
+                const buttonTarget = document.querySelector(`#anything-${user.id}`)
+                buttonTarget.showModal()
+              }}>
+              Deactivate
+            </button>
+            <h2>Admins approved: {user.admin_approval}</h2>
+          </div>
           :
           <button
             className="reactivate"

--- a/src/components/users/User.js
+++ b/src/components/users/User.js
@@ -105,6 +105,7 @@ export const User = ({ listView, user, currentUser, getUsers }) => {
                             isUser={true}
                             adminEdit={false}
                             user={user}
+                            currentUser={currentUser}
                             deactivate={deactivate}
                             reactivate={reactivate}
                         />
@@ -127,6 +128,7 @@ export const User = ({ listView, user, currentUser, getUsers }) => {
                             isUser={true}
                             adminEdit={true}
                             user={user}
+                            currentUser={currentUser}
                             addAdmin={addAdmin}
                             removeAdmin={removeAdmin}
                         />

--- a/src/components/users/User.js
+++ b/src/components/users/User.js
@@ -22,18 +22,12 @@ export const User = ({ listView, user, currentUser, getUsers }) => {
     const { userId } = useParams()
 
     const deactivate = () => {
-        let copy = { ...user }
-        copy.active = false
-        setViewUser(copy)
-        deactivateUser(copy)
+        deactivateUser(user)
             .then(() => getUsers())
     }
 
     const reactivate = () => {
-        let copy = { ...user }
-        copy.active = true
-        setViewUser(copy)
-        reactivateUser(copy)
+        reactivateUser(user)
             .then(() => getUsers())
     }
 

--- a/src/components/users/UserManager.js
+++ b/src/components/users/UserManager.js
@@ -24,11 +24,11 @@ export const getCurrentUser = () => {
 }
 
 export const deactivateUser = (user) => {
-    return fetchIt(`${Settings.API}/users/${user.id}/deactivate`, "PUT", JSON.stringify(user))
+    return fetchIt(`${Settings.API}/users/${user.id}/deactivate`, "PUT")
 }
 
 export const reactivateUser = (user) => {
-    return fetchIt(`${Settings.API}/users/${user.id}/reactivate`, "PUT", JSON.stringify(user))
+    return fetchIt(`${Settings.API}/users/${user.id}/reactivate`, "PUT")
 }
 
 export const promoteUser = (user) => {


### PR DESCRIPTION
# Description

Updated demote and deactivate buttons to display how many admins have given their approval, and updated reactivate and deactivate to be handled on the back-end

Fixes #47 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Log in as an admin
- [ ] Navigate to the users tab in the navbar
- [ ] Under deactivate and demote buttons the number of admins who have approved those actions should be visible
- [ ] Click demote on an admin who admin approval is 0
- [ ] When prompted to confirm it should should should an admins approved of 1
- [ ] Try to demote the same user to make sure you receive an alert telling you that the 2nd approval needs to be another admin
- [ ] Make sure you have another admin and log in to that user
- [ ] Navigate to users and try demoting the same user who should have an admins approved of 1
- [ ] When prompted and you confirm this time it should change the user type to author and the button should now be a promote button
- [ ] Repeat this process for the deactivate button on the left side of the users page

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings